### PR TITLE
fix: refactor ScreenListener out into its own class

### DIFF
--- a/BlackMarketSoldierStats/Src/BlackMarketSoldierStats/Classes/BlackMarketSoldierStats_MCM_ScreenListener.uc
+++ b/BlackMarketSoldierStats/Src/BlackMarketSoldierStats/Classes/BlackMarketSoldierStats_MCM_ScreenListener.uc
@@ -1,0 +1,27 @@
+class BlackMarketSoldierStats_MCM_ScreenListener extends UIScreenListener;
+
+event OnInit (UIScreen Screen)
+{
+	local BlackMarketSoldierStats_Settings MCMScreen;
+
+	if (ScreenClass == none)
+	{
+		if (MCM_API(Screen) != none)
+		{
+			ScreenClass = Screen.Class;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	MCMScreen = new class'BlackMarketSoldierStats_Settings';
+	MCMScreen.OnInit(Screen);
+}
+
+defaultproperties
+{
+    ScreenClass = none;
+}
+

--- a/BlackMarketSoldierStats/Src/BlackMarketSoldierStats/Classes/BlackMarketSoldierStats_Settings.uc
+++ b/BlackMarketSoldierStats/Src/BlackMarketSoldierStats/Classes/BlackMarketSoldierStats_Settings.uc
@@ -1,4 +1,4 @@
-class BlackMarketSoldierStats_Settings extends UIScreenListener config(BlackMarketSoldierStats_Settings);
+class BlackMarketSoldierStats_Settings extends Object config(BlackMarketSoldierStats_Settings);
 
 // Mod version
 const VERSION_MAJOR = 1;


### PR DESCRIPTION
Previously, the MCM Settings page extended `UIScreenListener` itself. While the settings page was picked up by ModConfigMenu, it crashed the game when opening the mod settings in the Shell and then loading a saved game.

Closes #16 